### PR TITLE
Refactor/migrate coach fullname to seperate

### DIFF
--- a/lib/features/registration/registration_page.dart
+++ b/lib/features/registration/registration_page.dart
@@ -18,32 +18,40 @@ class RegistrationPage extends StatefulWidget {
 
 class _RegistrationPageState extends State<RegistrationPage> {
   final _formKey = GlobalKey<FormState>();
-  final _fullNameController = TextEditingController();
+  final _firstNameController = TextEditingController();
+  final _lastNameController = TextEditingController();
   final _nicknameController = TextEditingController();
   final _selectedDuration = TextEditingController();
   String? _durationError;
 
   // Getters
-  String get _parsedFullName => _fullNameController.text.trim();
+  String get _parsedFirstName => _firstNameController.text.trim();
+  String get _parsedLastName => _lastNameController.text.trim();
   String get _parsedNickname => _nicknameController.text.trim();
   String get _parsedStringDuration => _selectedDuration.text;
   int get _parsedIntDuration => int.tryParse(_selectedDuration.text) ?? 0;
 
   late final ValueNotifier<String?> _selectedMembershipId;
   final List<MembershipType> _membershipTypes = [];
-  late Map<String, MembershipType> _membershipMap;
+  Map<String, MembershipType> _membershipMap = {};
   bool _isDiscountSelected = false;
+
+  // Coach selection
+  String? _selectedCoachId;
+  List<Map<String, dynamic>> _coaches = [];
 
   @override
   void initState() {
     super.initState();
     _selectedMembershipId = ValueNotifier<String?>(null);
     _loadMembershipTypes();
+    _loadCoaches();
   }
 
   @override
   void dispose() {
-    _fullNameController.dispose();
+    _firstNameController.dispose();
+    _lastNameController.dispose();
     _nicknameController.dispose();
     _selectedMembershipId.dispose();
     _selectedDuration.dispose();
@@ -59,6 +67,22 @@ class _RegistrationPageState extends State<RegistrationPage> {
       _membershipTypes.addAll(memberships);
       _membershipMap = {for (final m in memberships) m.id: m};
     });
+  }
+
+  Future<void> _loadCoaches() async {
+    final coaches = await MembershipService.fetchCoaches();
+    if (!mounted) return;
+    setState(() {
+      _coaches = coaches;
+    });
+  }
+
+  /// Whether the selected membership name is "Coaching"
+  bool get _isCoachingSelected {
+    final selId = _selectedMembershipId.value;
+    if (selId == null) return false;
+    final mt = _membershipMap[selId];
+    return mt?.name.toLowerCase() == 'coaching';
   }
 
   double _calculateTotal() {
@@ -84,7 +108,7 @@ class _RegistrationPageState extends State<RegistrationPage> {
   }
 
   void _handleContinue() {
-    if (_parsedFullName.isNotEmpty &&
+    if (_parsedFirstName.isNotEmpty &&
         _selectedMembershipId.value != null &&
         _selectedDuration.text.isNotEmpty) {
 
@@ -92,10 +116,12 @@ class _RegistrationPageState extends State<RegistrationPage> {
       
       debugPrint('''
         [USER DATA PACKAGED]:
-        FULL NAME: ${packagedUser['full_name']}
+        FIRST NAME: ${packagedUser['first_name']}
+        LAST NAME: ${packagedUser['last_name']}
         NICKNAME: ${packagedUser['nickname']}
         SELECTED MEMBERSHIP: ${packagedUser['membership_type_id']}
         MEMBERSHIP DURATION: ${packagedUser['membership_duration']}
+        COACH ID: ${packagedUser['coach_id']}
         DISCOUNTED: ${packagedUser['is_discounted']}
       ''');
 
@@ -106,11 +132,25 @@ class _RegistrationPageState extends State<RegistrationPage> {
   Map<String, dynamic> _packageRegistrationData() {
     Map<String, dynamic> registrationFields = {};
 
-    registrationFields['full_name'] = _parsedFullName;
-    registrationFields['nickname'] = _parsedNickname;
+    registrationFields['first_name'] = _parsedFirstName;
+    registrationFields['last_name'] = _parsedLastName.isNotEmpty ? _parsedLastName : null;
+    registrationFields['nickname'] = _parsedNickname.isNotEmpty ? _parsedNickname : null;
     registrationFields['membership_type_id'] = _selectedMembershipId.value;
     registrationFields['membership_duration'] = _parsedIntDuration;
     registrationFields['is_discounted'] = _isDiscountSelected;
+    registrationFields['coach_id'] = _isCoachingSelected ? _selectedCoachId : null;
+
+    // Resolve coach display name for the success page
+    if (registrationFields['coach_id'] != null) {
+      try {
+        final coach = _coaches.firstWhere(
+          (c) => c['id'] == registrationFields['coach_id'],
+        );
+        registrationFields['coach_name'] = coach['display_name'] ?? 'Coach';
+      } catch (_) {
+        // Coach not found in list
+      }
+    }
 
     return registrationFields;
   }
@@ -180,20 +220,30 @@ class _RegistrationPageState extends State<RegistrationPage> {
                     ),
                   ),
 
-                  const FormLabel(label: 'FULL NAME'),
+                  const FormLabel(label: 'FIRST NAME'),
                   CustomAppTextField(
-                    controller: _fullNameController,
-                    hintText: 'e.g. Alex Johnson',
+                    controller: _firstNameController,
+                    hintText: 'e.g. Alex',
                     icon: Icons.badge_outlined,
                     inputFormatters: [
                       FilteringTextInputFormatter.allow(RegExp(r'[a-zA-Z\s]')),
                     ],
                     validator: (value) {
                       if (value == null || value.isEmpty) {
-                        return 'Please enter your full name';
+                        return 'Please enter your first name';
                       }
                       return null;
                     },
+                  ),
+
+                  const FormLabel(label: 'LAST NAME (OPTIONAL)'),
+                  CustomAppTextField(
+                    controller: _lastNameController,
+                    hintText: 'e.g. Johnson',
+                    icon: Icons.badge_outlined,
+                    inputFormatters: [
+                      FilteringTextInputFormatter.allow(RegExp(r'[a-zA-Z\s]')),
+                    ],
                   ),
 
                   const FormLabel(label: 'NICKNAME (OPTIONAL)'),
@@ -215,11 +265,34 @@ class _RegistrationPageState extends State<RegistrationPage> {
                         membership.id: membership.name,
                     },
                     value: _selectedMembershipId.value,
-                    onChanged: (val) =>
-                        setState(() => _selectedMembershipId.value = val),
+                    onChanged: (val) {
+                      setState(() {
+                        _selectedMembershipId.value = val;
+                        // Reset coach when switching away from Coaching
+                        if (!_isCoachingSelected) {
+                          _selectedCoachId = null;
+                        }
+                      });
+                    },
                     validator: (value) =>
                         value == null ? 'Please select membership' : null,
                   ),
+
+                  // Coach dropdown — only visible when Coaching is selected
+                  if (_isCoachingSelected) ...[
+                    const FormLabel(label: 'ASSIGN COACH'),
+                    CustomAppDropDown(
+                      hintText: 'Select a coach',
+                      icon: Icons.assignment_ind_outlined,
+                      items: {
+                        for (final coach in _coaches)
+                          coach['id'] as String: coach['display_name'] as String,
+                      },
+                      value: _selectedCoachId,
+                      onChanged: (val) =>
+                          setState(() => _selectedCoachId = val),
+                    ),
+                  ],
 
                   FormLabel(label: 'DURATION', error: _durationError),
                   CustomAppTextField(
@@ -326,13 +399,13 @@ class _RegistrationPageState extends State<RegistrationPage> {
                   const SizedBox(height: 20),
                   ListenableBuilder(
                     listenable: Listenable.merge([
-                      _fullNameController,
+                      _firstNameController,
                       _selectedMembershipId,
                       _selectedDuration,
                     ]),
                     builder: (context, child) {
                       final isValid =
-                          _parsedFullName.isNotEmpty &&
+                          _parsedFirstName.isNotEmpty &&
                           _selectedMembershipId.value != null &&
                           _parsedStringDuration.isNotEmpty;
                       return SizedBox(

--- a/lib/features/registration/registration_page.dart
+++ b/lib/features/registration/registration_page.dart
@@ -139,6 +139,7 @@ class _RegistrationPageState extends State<RegistrationPage> {
     registrationFields['membership_duration'] = _parsedIntDuration;
     registrationFields['is_discounted'] = _isDiscountSelected;
     registrationFields['coach_id'] = _isCoachingSelected ? _selectedCoachId : null;
+    registrationFields['total_fee'] = _calculateTotal();
 
     // Resolve coach display name for the success page
     if (registrationFields['coach_id'] != null) {

--- a/lib/features/registration/staff_authorization_page.dart
+++ b/lib/features/registration/staff_authorization_page.dart
@@ -22,11 +22,12 @@ class _StaffAuthorizationPageState extends State<StaffAuthorizationPage> {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    
+
     // Only read route arguments once to avoid redundant processing
     if (!_didReadArgs) {
       // Retrieve the user data passed from the previous screen via Navigator
-      userData = ModalRoute.of(context)!.settings.arguments as Map<String, dynamic>?;
+      userData =
+          ModalRoute.of(context)!.settings.arguments as Map<String, dynamic>?;
 
       // Display error if no registration data was provided
       if (userData == null) {
@@ -34,7 +35,7 @@ class _StaffAuthorizationPageState extends State<StaffAuthorizationPage> {
           errorMessage = 'Registration data missing';
         });
       }
-      
+
       // Mark arguments as read to prevent re-execution
       _didReadArgs = true;
     }
@@ -55,7 +56,7 @@ class _StaffAuthorizationPageState extends State<StaffAuthorizationPage> {
       _handleError('Failed to read QR code');
       return;
     }
-    
+
     /// QrScanner isProcessing after it detects a QR.
     /// Clears errorMessage so it does not get displayed.
     setState(() {
@@ -68,7 +69,7 @@ class _StaffAuthorizationPageState extends State<StaffAuthorizationPage> {
     if (qrParts == null || !validStaffQrFormat(qrParts)) {
       _handleError('Invalid QR Format');
       return;
-    } 
+    }
 
     // Extract the required qr once verified
     final staffShortId = qrParts[2];
@@ -76,11 +77,11 @@ class _StaffAuthorizationPageState extends State<StaffAuthorizationPage> {
 
     // Verify is qrToken belongs to staff
     if (!await staffExists(staffQrToken, staffShortId)) {
-     _handleError('Invalid Staff');
+      _handleError('Invalid Staff');
       return;
     }
 
-    // Verification success: Generate member credentials and assign 
+    // Verification success: Generate member credentials and assign
     try {
       await MemberRegistrationService.registerNewUser(userData!);
     } catch (e) {
@@ -127,7 +128,7 @@ class _StaffAuthorizationPageState extends State<StaffAuthorizationPage> {
           // Full-screen Scanner
           QRScannerView(onDetect: _handleQrDetection),
 
-          if (errorMessage != null) 
+          if (errorMessage != null)
             Positioned(
               bottom: 24,
               left: 24,
@@ -198,7 +199,7 @@ class _StaffAuthorizationPageState extends State<StaffAuthorizationPage> {
                     ),
                     const SizedBox(height: 12),
                     const Text(
-                      'Scan your staff QR code to authorize\nnew member registration',
+                      'Scan a verified staff QR to authorize\nnew member registration',
                       textAlign: TextAlign.center,
                       style: TextStyle(
                         fontSize: 15,

--- a/lib/features/registration/success_page.dart
+++ b/lib/features/registration/success_page.dart
@@ -53,10 +53,21 @@ class _SuccessPageState extends State<SuccessPage> {
     }
   }
 
-  String get _fullName => _memberData?['full_name'] ?? 'Unknown';
+  String get _fullName {
+    final first = (_memberData?['first_name'] ?? '').toString();
+    final last = (_memberData?['last_name'] ?? '').toString();
+    final combined = '$first $last'.trim();
+    return combined.isNotEmpty ? combined : 'Unknown';
+  }
+
+  String get _password => (_memberData?['password'] ?? '').toString();
+
   String? get _coachId => _memberData?['coach_id'] as String?;
-  String get _coachLabel =>
-      (_coachId?.isNotEmpty ?? false) ? 'Coach $_coachId' : 'No Coach';
+  String get _coachLabel {
+    final coachName = _memberData?['coach_name'] as String?;
+    if (coachName != null && coachName.isNotEmpty) return coachName;
+    return 'No Coach';
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -367,7 +378,7 @@ class _SuccessPageState extends State<SuccessPage> {
           ),
           const Spacer(),
           Text(
-            _obscurePassword ? '••••••••' : 'Pass1234',
+            _obscurePassword ? '••••••••' : _password,
             style: const TextStyle(
               fontSize: 14,
               fontFamily: 'Lexend',

--- a/lib/models/schema.dart
+++ b/lib/models/schema.dart
@@ -4,7 +4,8 @@ const schema = Schema([
   Table('users', [
     Column.text('auth_user_id'),
     Column.text('short_id'),
-    Column.text('full_name'),
+    Column.text('first_name'),
+    Column.text('last_name'),
     Column.text('nickname'),
     Column.text('contact_number'),
     Column.text('role'),

--- a/lib/models/user.dart
+++ b/lib/models/user.dart
@@ -1,22 +1,29 @@
 class User {
-  final String _fullName;
+  final String _firstName;
+  final String? _lastName;
   final String? _nickname;
   final String _membershipTypeID; // uuid
   final DateTime _startedDate; // start date of their membership
   final DateTime _validUntil; // end date of their membership
 
   User({
-    required String fullName,
+    required String firstName,
+    String? lastName,
     String? nickname,
     required String membershipTypeID,
     required DateTime startedDate,
     required DateTime validUntil
-  })  : _fullName = fullName,
+  })  : _firstName = firstName,
+        _lastName = lastName,
         _nickname = nickname,
         _membershipTypeID = membershipTypeID,
         _startedDate = startedDate,
         _validUntil = validUntil;
 
+  String get displayName {
+    final full = [_firstName, _lastName].where((s) => s != null && s.isNotEmpty).join(' ');
+    return (_nickname?.isNotEmpty ?? false) ? _nickname! : full;
+  }
 }
 
 // Maps user data from object to JSON and vice versa
@@ -25,7 +32,8 @@ class UserMapper {
   // Maps JSON data to User object
   User fromJson(Map<String, dynamic> json) {
     return User(
-      fullName: json['full_name'],
+      firstName: json['first_name'],
+      lastName: json['last_name'],
       nickname: json['nickname'],
       membershipTypeID: json['membership_type_id'],
       startedDate: json['started_date'],
@@ -37,7 +45,8 @@ class UserMapper {
   // Use this to pass the object as JSON object to Staff Authorization
   Map<String, dynamic> toJson(User user) {
     return {
-      'full_name': user._fullName,
+      'first_name': user._firstName,
+      'last_name': user._lastName,
       'nickname': user._nickname,
       'membership_type_id': user._membershipTypeID,
       'started_date' : user._startedDate,

--- a/lib/services/member_registration_service.dart
+++ b/lib/services/member_registration_service.dart
@@ -14,12 +14,13 @@ class MemberRegistrationService {
 
     await db.writeTransaction((tx) async {
       await tx.execute('''
-        INSERT INTO users (id, short_id, full_name, nickname, role, qr_token)
-        VALUES (?, ?, ?, ?, ?, ?)
+        INSERT INTO users (id, short_id, first_name, last_name, nickname, role, qr_token)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
       ''', [
         userData['id'], 
         userData['short_id'], 
-        userData['full_name'], 
+        userData['first_name'], 
+        userData['last_name'],
         userData['nickname'], 
         'Member', 
         userData['qr_token']
@@ -46,6 +47,11 @@ class MemberRegistrationService {
     userData['id'] = const Uuid().v4(); // Generate UUID 
     userData['short_id'] = await generateUniqueShortId();
     userData['qr_token'] = await generateUniqueQrToken();
+
+    // Generate password: lowercase stripped first_name + short_id
+    final firstName = (userData['first_name'] as String?) ?? '';
+    final shortId = userData['short_id'] as String;
+    userData['password'] = firstName.toLowerCase().replaceAll(RegExp(r'[^a-z0-9]'), '') + shortId;
 
     /// Initialize membership duration
     DateTime today = DateTime.now();

--- a/lib/services/member_registration_service.dart
+++ b/lib/services/member_registration_service.dart
@@ -1,6 +1,7 @@
 import 'dart:math';
 
 import 'package:project_e_qr_app/main.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
 import 'package:uuid/uuid.dart';
 
 /// Handles credential generation, staff qr validation, 
@@ -39,6 +40,37 @@ class MemberRegistrationService {
         userData['is_discounted']
       ]);
     });
+
+    // Write renewal log directly to Supabase — fire-and-forget retry
+    // because PowerSync needs time to sync the member row first (FK constraint)
+    _insertRenewalLog(userData);
+  }
+
+  /// Inserts a renewal log entry to Supabase with retries.
+  /// Runs in background so it doesn't block the registration flow.
+  static Future<void> _insertRenewalLog(Map<String, dynamic> userData) async {
+    final payload = {
+      'id': const Uuid().v4(),
+      'member_id': userData['id'],
+      'membership_type_id': userData['membership_type_id'],
+      'valid_from': userData['started_date'],
+      'valid_until': userData['valid_until'],
+      'is_discounted': userData['is_discounted'] == true,
+      'fee_applied': userData['total_fee'] ?? 0.0,
+      'is_new_member': true,
+    };
+
+    for (int attempt = 1; attempt <= 5; attempt++) {
+      await Future.delayed(Duration(seconds: attempt * 2));
+      try {
+        await Supabase.instance.client.from('member_renewal_logs').insert(payload);
+        print('[MemberRegistrationService] Renewal log written (attempt $attempt)');
+        return;
+      } catch (e) {
+        print('[MemberRegistrationService] Renewal log attempt $attempt failed: $e');
+      }
+    }
+    print('[MemberRegistrationService] Renewal log failed after 5 attempts');
   }
 
   /// Generates the necessary fields after the user fills in the fields

--- a/lib/services/membership_service.dart
+++ b/lib/services/membership_service.dart
@@ -16,4 +16,29 @@ class MembershipService {
       return [];
     }
   }
+
+  /// Fetches coaches from the local PowerSync DB.
+  /// Returns a list of maps with 'id' and 'display_name' keys.
+  static Future<List<Map<String, dynamic>>> fetchCoaches() async {
+    try {
+      final rows = await db.getAll('''
+        SELECT u.id,
+               TRIM(COALESCE(u.first_name, '') || ' ' || COALESCE(u.last_name, '')) AS display_name
+        FROM users u
+        JOIN staff s ON s.id = u.id
+        WHERE s.subrole = 'Coach'
+        ORDER BY u.first_name
+      ''');
+
+      return rows
+          .where((r) => (r['id'] ?? '').toString().isNotEmpty)
+          .map((r) => {
+                'id': r['id'].toString(),
+                'display_name': (r['display_name'] ?? 'Coach').toString().trim(),
+              })
+          .toList();
+    } catch (_) {
+      return [];
+    }
+  }
 }

--- a/lib/services/qr_validator.dart
+++ b/lib/services/qr_validator.dart
@@ -84,7 +84,7 @@ class QrValidator {
         SELECT
           u.id,
           u.role,
-          COALESCE(NULLIF(u.nickname, ''), u.full_name) AS display_name,
+          COALESCE(NULLIF(u.nickname, ''), TRIM(COALESCE(u.first_name, '') || ' ' || COALESCE(u.last_name, ''))) AS display_name,
           m.status AS member_status,
           m.valid_until
         FROM users u


### PR DESCRIPTION
# Submitting a Pull Request

> [!IMPORTANT]
> Before submitting this pull request, please make sure to link the related issue by referencing it in your description.
> You can do this by adding a comment such as `Resolves #<issue_number>` or `Closes #<issue_number>`, e.g.,  
> `Fixes #5`
>
> This will automatically link and close the issue when your pull request is merged.

**Type of Change**

resolves #31 and resolves #20 

<!-- Mark with an 'X' for all that apply -->

- [ ] Bug fix — resolves a problem without breaking existing functionality
- [x] New feature — introduces or enhances functionality
- [ ] Documentation — updates or adds documentation only
- [x] Refactor — code change with no user-facing impact
- [x] Breaking change — change that affects existing functionality

**Summary of Changes**

<!-- List the key changes included in this pull request. Use bullet points for clarity. -->

- Migrated PowerSync schema from `full_name` to `first_name` + `last_name`
- Refactored Registration form from single "Full Name" field to split "First Name" / "Last Name (Optional)" fields
- Implemented dynamic coach dropdown — fetches coaches from local PowerSync DB, only visible when "Coaching" membership is selected
- Fixed Success page to show real generated password (`normalize(first_name) + short_id`) instead of hardcoded `Pass1234`
- Fixed Success page to display coach name instead of raw UUID
- Fixed QR Validator SQL query to compose display name from `first_name || last_name` instead of dropped `full_name` column
- Implemented `member_renewal_logs` integration — writes directly to Supabase via REST with retry pattern for revenue analytics tracking
- Added `fetchCoaches()` to `MembershipService` for dynamic coach loading from local DB
- Updated User model with `firstName` / `lastName` fields and `displayName` getter

